### PR TITLE
remove unneeded unicode handling

### DIFF
--- a/js/cards/parsecards.py
+++ b/js/cards/parsecards.py
@@ -48,10 +48,6 @@ for card in cards:
     # We're going to store them in lowercase
     ocard = card.lower()
 
-    # Python's Unicode support sucks, as does everybodies.  Manually
-    # replace the Ae to lower case
-    ocard = ocard.replace(u'\xc6', u'\xe6')
-
     # Skip tokens
     if cards[card]['layout'] == 'token': continue
 
@@ -93,7 +89,6 @@ for card in cards:
     # Now to handle split cards (ugh)
     if 'names' in cards[card]:
         name = " // ".join(cards[card]['names'])
-        ocard = name.lower().replace(u'\xc6', u'\xe6')   # Just like a real card
 
         ocards[ocard] = {}
         ocards[ocard]['c'] = 'S'

--- a/js/decklist/decklist.js
+++ b/js/decklist/decklist.js
@@ -119,7 +119,11 @@ function parseDecklist() {
   // appropriate list (main or side), otherwise add it to the unrecognized map.
   function recognizeCard(card, quantity, list) {
     list = list || 'main';
-      recognized = objectHasPropertyCI(cards, card);
+	
+	  // Only perform lookup using "ae", not "Æ" or "æ"
+      card = card.replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
+      
+	  recognized = objectHasPropertyCI(cards, card);
 
     // Always add the card to the list, regardless of if the card is recognized
     // Still, if not recognized, add it to its special dictionary (unrecognized)

--- a/js/decklist/decklist.js
+++ b/js/decklist/decklist.js
@@ -119,13 +119,7 @@ function parseDecklist() {
   // appropriate list (main or side), otherwise add it to the unrecognized map.
   function recognizeCard(card, quantity, list) {
     list = list || 'main';
-    var aeloc = card.toLowerCase().indexOf('ae');
-
-    if (aeloc != -1) {
-      recognized = objectHasPropertyCI(cards, card.slice(0, aeloc)+'\u00e6'+card.slice(aeloc+2)) ||
-      objectHasPropertyCI(cards, card);;
-    }
-    else { recognized = objectHasPropertyCI(cards, card); }
+      recognized = objectHasPropertyCI(cards, card);
 
     // Always add the card to the list, regardless of if the card is recognized
     // Still, if not recognized, add it to its special dictionary (unrecognized)
@@ -190,10 +184,6 @@ function sortDecklist(deck, sortorder) {
       // Create the color subarray
       if ( !(color in color_to_cards ) ) { color_to_cards[color] = []; }
 
-      // Fix the Aetherling issue until the PDF things supports it
-      lcard = lcard.replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
-      deck[i][0] = deck[i][0].replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
-
       // Add the card to that array, including lower-case (only used for sorting)
       color_to_cards[color].push( [ lcard, deck[i][0], deck[i][1] ] );
 
@@ -251,10 +241,6 @@ function sortDecklist(deck, sortorder) {
 
       // Create the cmc subarray
       if ( !(cmc in cmc_to_cards ) ) { cmc_to_cards[cmc] = []; }
-
-      // Fix the Aetherling issue until the PDF things supports it
-      lcard = lcard.replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
-      deck[i][0] = deck[i][0].replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
 
       // Add the card to that array, including lower-case (only used for sorting)
       cmc_to_cards[cmc].push( [ lcard, deck[i][0], deck[i][1] ] );
@@ -322,10 +308,6 @@ function sortDecklist(deck, sortorder) {
 
       // Create the type subarray
       if ( !(type in type_to_cards ) ) { type_to_cards[type] = []; }
-
-      // Fix the Aetherling issue until the PDF things supports it
-      lcard = lcard.replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
-      deck[i][0] = deck[i][0].replace('\u00c6', 'Ae').replace('\u00e6', 'ae');
 
       // Add the card to that array, including lower-case (only used for sorting)
       type_to_cards[type].push( [ lcard, deck[i][0], deck[i][1] ] );


### PR DESCRIPTION
>**The Æ Ligature (Non-Functional)**
>
>Æ, pronounced "ash," is the loneliest ligature. How many of you even knew what it was called? With the introduction of Aetherborn and no desire whatsoever to ask people to type Ætherborn, that letter also has no place in Oracle anymore, and forty-four cards got an exceptionally rare name change in the Oracle card reference.

from https://magic.wizards.com/en/articles/archive/feature/kaladesh-update-bulletin-2016-09-30

Some time ago the regarding unicode characters got removed from all cards by wizards.
Your [card source "mtgjson"](https://github.com/april/decklist/blob/master/js/cards/generatecards.sh#L6), reflects that change [since version 3.10.4](https://mtgjson.com/changelog.html), too.
In return that character can't show up any longer.